### PR TITLE
Don't overwrite to webkitAudioContext unless needed

### DIFF
--- a/components/Play.coffee
+++ b/components/Play.coffee
@@ -9,8 +9,10 @@ class Play extends noflo.Component
     @table_audionodes = {}
     @buffer_data = {}
     if (!window.nofloWebAudioContext)
-      context = new AudioContext() if AudioContext?
-      context = new webkitAudioContext() if webkitAudioContext?
+      if AudioContext?
+        context = new AudioContext
+      else if webkitAudioContext?
+        context = new webkitAudioContext
       window.nofloWebAudioContext = context
     @context = window.nofloWebAudioContext
     @tuna = new Tuna(@context)


### PR DESCRIPTION
Chrome complains about webkitAudioContext being deprecated. This ensure we use AudioContext unless we need to fall back to webkitAudioContext
